### PR TITLE
Feat: add multi-stage build with Prisma generate for enhanced performance and security

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,39 +1,49 @@
-# Use a lightweight Node.js image as base
+# Build stage
+FROM node:20-alpine3.18 AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+COPY prisma ./prisma/
+
+# Install all dependencies for build
+RUN npm ci
+
+# Generate Prisma client
+RUN npx prisma generate
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Production stage
 FROM node:20-alpine3.18
 
 # Create app user and group for security
 RUN addgroup app && adduser -S -G app app
 
-# Switch to app user
-USER app
-
-# Set working directory inside container
 WORKDIR /app
 
-# Copy package.json and package-lock.json first for caching
+# Copy package files
 COPY package*.json ./
+COPY prisma ./prisma/
 
-# Switch to root temporarily to change permissions
-USER root
-# Change ownership of the working directory to the app user
-# chown -R <user>:<group> <directory>
-# chown command changes the user and/or group ownership of for given file.
-RUN chown -R app:app .
-
-# Switch back to app user
-USER app
-
-# Install ALL dependencies (including dev) for build
-RUN npm ci
-
-# Copy the rest of the source code
-COPY . .
-
-# Compile TypeScript into dist/
-RUN npm run build
-
-# Install only production dependencies for runtime
+# Install only production dependencies
 RUN npm ci --only=production
+
+# Generate Prisma client for production (needs the schema)
+RUN npx prisma generate
+
+# Copy built application from builder stage
+COPY --from=builder /app/dist ./dist
+# Copy any other necessary files
+COPY --from=builder /app/package.json ./package.json
+
+# Switch to app user
+USER app
 
 # Expose the port for the backend server
 EXPOSE 9101


### PR DESCRIPTION
This pull request refactors the `backend/Dockerfile` to implement a multi-stage build process, improving security, efficiency, and separation between build and production environments. The changes streamline dependency installation, ensure the Prisma client is generated in both stages, and properly handle user permissions.

**Docker build process improvements:**

* Switched to a multi-stage build with separate `builder` and production stages, reducing the final image size and attack surface.
* Ensured only production dependencies are installed in the final image by running `npm ci --only=production` in the production stage.
* Generated the Prisma client in both build and production stages to ensure compatibility and functionality.

**Security and user management:**

* Explicitly created and used a non-root `app` user and group in the production image for improved container security.

**General improvements:**

* Improved build caching by copying only necessary files at each stage and separating dependency installation from application code copying.